### PR TITLE
feat: replace with custom log

### DIFF
--- a/app_config.go
+++ b/app_config.go
@@ -6,7 +6,6 @@ import (
 	"time"
 	"fmt"
 	"net/url"
-	"github.com/cihub/seelog"
 	"encoding/json"
 )
 
@@ -165,12 +164,12 @@ func syncServerIpListSuccessCallBack(responseBody []byte)(o interface{},err erro
 	err= json.Unmarshal(responseBody,&tmpServerInfo)
 
 	if err!=nil{
-		seelog.Error("Unmarshal json Fail,Error:",err)
+		logger.Error("Unmarshal json Fail,Error:",err)
 		return
 	}
 
 	if len(tmpServerInfo)==0 {
-		seelog.Info("get no real server!")
+		logger.Info("get no real server!")
 		return
 	}
 
@@ -193,7 +192,7 @@ func syncServerIpList() error{
 		panic("can not find apollo config!please confirm!")
 	}
 	url:=getServicesConfigUrl(appConfig)
-	seelog.Debug("url:",url)
+	logger.Debug("url:",url)
 
 	_,err:=request(url,&ConnectConfig{
 	},&CallBack{
@@ -213,7 +212,7 @@ func initRefreshInterval() error {
 	if isNotEmpty(customizedRefreshInterval){
 		interval,err:=strconv.Atoi(customizedRefreshInterval)
 		if isNotNil(err) {
-			seelog.Errorf("Config for apollo.refreshInterval is invalid:%s",customizedRefreshInterval)
+			logger.Errorf("Config for apollo.refreshInterval is invalid:%s",customizedRefreshInterval)
 			return err
 		}
 		refresh_interval=time.Duration(interval)

--- a/app_config_server_test.go
+++ b/app_config_server_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"fmt"
 	//"time"
-	"github.com/cihub/seelog"
 )
 
 const servicesConfigResponseStr  =`[{
@@ -74,10 +73,10 @@ func runMockServicesConfigServer(handler func(http.ResponseWriter, *http.Request
 	//server.ListenAndServe()
 
 
-	seelog.Info("mock notify server:",appConfig.Ip)
+	logger.Info("mock notify server:",appConfig.Ip)
 	err:=http.ListenAndServe(fmt.Sprintf("%s",appConfig.Ip), nil)
 	if err!=nil{
-		seelog.Error("runMockConfigServer err:",err)
+		logger.Error("runMockConfigServer err:",err)
 	}
 }
 

--- a/componet_notify.go
+++ b/componet_notify.go
@@ -4,7 +4,6 @@ import (
 	"time"
 	"encoding/json"
 	"sync"
-	"github.com/cihub/seelog"
 )
 
 
@@ -44,7 +43,7 @@ func toApolloConfig(resBody []byte) ([]*apolloNotify,error) {
 	err:=json.Unmarshal(resBody,&remoteConfig)
 
 	if err!=nil{
-		seelog.Error("Unmarshal Msg Fail,Error:",err)
+		logger.Error("Unmarshal Msg Fail,Error:",err)
 		return nil,err
 	}
 	return remoteConfig,nil

--- a/componet_timer.go
+++ b/componet_timer.go
@@ -2,7 +2,6 @@ package agollo
 
 import (
 	"time"
-	"github.com/cihub/seelog"
 )
 
 type AutoRefreshConfigComponent struct {
@@ -29,7 +28,7 @@ func autoSyncConfigServicesSuccessCallBack(responseBody []byte)(o interface{},er
 	apolloConfig,err:=createApolloConfigWithJson(responseBody)
 
 	if err!=nil{
-		seelog.Error("Unmarshal Msg Fail,Error:",err)
+		logger.Error("Unmarshal Msg Fail,Error:",err)
 		return nil,err
 	}
 

--- a/config_server_test.go
+++ b/config_server_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"fmt"
 	"time"
-	"github.com/cihub/seelog"
 )
 
 const configResponseStr  =`{
@@ -30,7 +29,7 @@ func runMockConfigServer(handler func(http.ResponseWriter, *http.Request)) {
 
 	err:=http.ListenAndServe(fmt.Sprintf("%s",appConfig.Ip), nil)
 	if err!=nil{
-		seelog.Error("runMockConfigServer err:",err)
+		logger.Error("runMockConfigServer err:",err)
 	}
 }
 

--- a/json_config_test.go
+++ b/json_config_test.go
@@ -76,7 +76,6 @@ func TestCreateAppConfigWithJsonError(t *testing.T) {
 import (
 	"os"
 	"strconv"
-	"github.com/cihub/seelog"
 	"time"
 	"fmt"
 	"net/url"

--- a/log.go
+++ b/log.go
@@ -4,11 +4,35 @@ import (
 	"github.com/cihub/seelog"
 )
 
-func init(){
-	initSeeLog("seelog.xml")
+var logger LoggerInterface
+
+func init() {
+	initLogger(initSeeLog("seelog.xml"))
 }
 
-func initSeeLog(configPath string)  {
+func initLogger(ILogger LoggerInterface) {
+	logger = ILogger
+}
+
+type LoggerInterface interface {
+	Debugf(format string, params ...interface{})
+
+	Infof(format string, params ...interface{})
+
+	Warnf(format string, params ...interface{}) error
+
+	Errorf(format string, params ...interface{}) error
+
+	Debug(v ...interface{})
+
+	Info(v ...interface{})
+
+	Warn(v ...interface{}) error
+
+	Error(v ...interface{}) error
+}
+
+func initSeeLog(configPath string) (LoggerInterface) {
 	logger, err := seelog.LoggerFromConfigAsFile(configPath)
 
 	//if error is happen change to default config.
@@ -19,4 +43,6 @@ func initSeeLog(configPath string)  {
 	logger.SetAdditionalStackDepth(1)
 	seelog.ReplaceLogger(logger)
 	defer seelog.Flush()
+
+	return logger
 }

--- a/notify_server_test.go
+++ b/notify_server_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"fmt"
 	"time"
-	"github.com/cihub/seelog"
 )
 
 const responseStr  =`[{"namespaceName":"application","notificationId":%d}]`
@@ -18,10 +17,10 @@ func runMockNotifyServer(handler func(http.ResponseWriter, *http.Request)) {
 		panic("can not find apollo config!please confirm!")
 	}
 
-	seelog.Info("runMockNotifyServer:",appConfig.Ip)
+	logger.Info("runMockNotifyServer:",appConfig.Ip)
 	err:=http.ListenAndServe(fmt.Sprintf("%s",appConfig.Ip), nil)
 	if err!=nil{
-		seelog.Error("runMockConfigServer err:",err)
+		logger.Error("runMockConfigServer err:",err)
 	}
 }
 

--- a/repository.go
+++ b/repository.go
@@ -2,7 +2,6 @@ package agollo
 
 import (
 	"strconv"
-	"github.com/cihub/seelog"
 	"github.com/coocood/freecache"
 )
 
@@ -24,7 +23,7 @@ var (
 
 func updateApolloConfig(apolloConfig *ApolloConfig)  {
 	if apolloConfig==nil{
-		seelog.Error("apolloConfig is null,can't update!")
+		logger.Error("apolloConfig is null,can't update!")
 		return
 	}
 	go updateApolloConfigCache(apolloConfig.Configurations,configCacheExpireTime)
@@ -89,7 +88,7 @@ func GetCurrentApolloConfig()*ApolloConnConfig  {
 func getConfigValue(key string) interface{}  {
 	value,err:=apolloConfigCache.Get([]byte(key))
 	if err!=nil{
-		seelog.Error("get config value fail!err:",err)
+		logger.Error("get config value fail!err:",err)
 		return empty
 	}
 
@@ -120,7 +119,7 @@ func GetIntValue(key string,defaultValue int) int {
 
 	i,err:=strconv.Atoi(value)
 	if err!=nil{
-		seelog.Debug("convert to int fail!error:",err)
+		logger.Debug("convert to int fail!error:",err)
 		return defaultValue
 	}
 
@@ -132,7 +131,7 @@ func GetFloatValue(key string,defaultValue float64) float64 {
 
 	i,err:=strconv.ParseFloat(value,64)
 	if err!=nil{
-		seelog.Debug("convert to float fail!error:",err)
+		logger.Debug("convert to float fail!error:",err)
 		return defaultValue
 	}
 
@@ -144,7 +143,7 @@ func GetBoolValue(key string,defaultValue bool) bool {
 
 	b,err:=strconv.ParseBool(value)
 	if err!=nil{
-		seelog.Debug("convert to bool fail!error:",err)
+		logger.Debug("convert to bool fail!error:",err)
 		return defaultValue
 	}
 

--- a/request.go
+++ b/request.go
@@ -62,7 +62,7 @@ func request(requestUrl string,connectionConfig *ConnectConfig,callBack *CallBac
 				return nil,nil
 			}
 		case http.StatusNotModified:
-			seelog.Info("Config Not Modified:", err)
+			logger.Info("Config Not Modified:", err)
 			if callBack!=nil&&callBack.NotModifyCallBack!=nil {
 				return nil,callBack.NotModifyCallBack()
 			}else{

--- a/request.go
+++ b/request.go
@@ -2,7 +2,6 @@ package agollo
 
 import (
 	"net/http"
-	"github.com/cihub/seelog"
 	"io/ioutil"
 	"time"
 	"errors"
@@ -44,7 +43,7 @@ func request(requestUrl string,connectionConfig *ConnectConfig,callBack *CallBac
 		res,err=client.Get(requestUrl)
 
 		if res==nil||err!=nil{
-			seelog.Error("Connect Apollo Server Fail,Error:",err)
+			logger.Error("Connect Apollo Server Fail,Error:",err)
 			continue
 		}
 
@@ -53,7 +52,7 @@ func request(requestUrl string,connectionConfig *ConnectConfig,callBack *CallBac
 		case http.StatusOK:
 			responseBody, err = ioutil.ReadAll(res.Body)
 			if err!=nil{
-				seelog.Error("Connect Apollo Server Fail,Error:",err)
+				logger.Error("Connect Apollo Server Fail,Error:",err)
 				continue
 			}
 
@@ -63,16 +62,16 @@ func request(requestUrl string,connectionConfig *ConnectConfig,callBack *CallBac
 				return nil,nil
 			}
 		case http.StatusNotModified:
-			seelog.Warn("Config Not Modified:", err)
+			logger.Warn("Config Not Modified:", err)
 			if callBack!=nil&&callBack.NotModifyCallBack!=nil {
 				return nil,callBack.NotModifyCallBack()
 			}else{
 				return nil,nil
 			}
 		default:
-			seelog.Error("Connect Apollo Server Fail,Error:",err)
+			logger.Error("Connect Apollo Server Fail,Error:",err)
 			if res!=nil{
-				seelog.Error("Connect Apollo Server Fail,StatusCode:",res.StatusCode)
+				logger.Error("Connect Apollo Server Fail,StatusCode:",res.StatusCode)
 			}
 			err=errors.New("Connect Apollo Server Fail!")
 			// if error then sleep
@@ -81,7 +80,7 @@ func request(requestUrl string,connectionConfig *ConnectConfig,callBack *CallBac
 		}
 	}
 
-	seelog.Error("Over Max Retry Still Error,Error:",err)
+	logger.Error("Over Max Retry Still Error,Error:",err)
 	if err!=nil{
 		err=errors.New("Over Max Retry Still Error!")
 	}

--- a/request_server_test.go
+++ b/request_server_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"time"
-	"github.com/cihub/seelog"
 )
 
 var IP1="localhost:7080"
@@ -59,10 +58,10 @@ func mockConfigServerListen(ip string,handler func(http.ResponseWriter, *http.Re
 		panic("can not find apollo config!please confirm!")
 	}
 
-	seelog.Info("mockConfigServerListen:",appConfig.Ip)
+	logger.Info("mockConfigServerListen:",appConfig.Ip)
 	err:=http.ListenAndServe(fmt.Sprintf("%s",ip), nil)
 	if err!=nil{
-		seelog.Error("runMockConfigServer err:",err)
+		logger.Error("runMockConfigServer err:",err)
 	}
 }
 

--- a/start.go
+++ b/start.go
@@ -2,6 +2,14 @@ package agollo
 
 //start apollo
 func Start() {
+	StartWithLogger(nil)
+}
+
+func StartWithLogger(loggerInterface LoggerInterface) {
+	if loggerInterface != nil {
+		initLogger(loggerInterface)
+	}
+
 	//first sync
 	notifySyncConfigServices()
 


### PR DESCRIPTION
由于公司内部使用的是自定义log实现，希望可以在Start时传入logger替换默认的seelog.
如果仍然需要使用seelog，可以调用原先的Start()