### PR TITLE
Update start.go

### DIFF
--- a/start.go
+++ b/start.go
@@ -1,21 +1,23 @@
 package agollo
 
 //start apollo
-func Start() {
-	StartWithLogger(nil)
+func Start() error {
+	return StartWithLogger(nil)
 }
 
-func StartWithLogger(loggerInterface LoggerInterface) {
+func StartWithLogger(loggerInterface LoggerInterface) error {
 	if loggerInterface != nil {
 		initLogger(loggerInterface)
 	}
 
 	//first sync
-	notifySyncConfigServices()
+	error := notifySyncConfigServices()
 
 	//start auto refresh config
 	go StartRefreshConfig(&AutoRefreshConfigComponent{})
 
 	//start long poll sync config
 	go StartRefreshConfig(&NotifyConfigComponent{})
+	
+	return error
 }


### PR DESCRIPTION
当server无法访问或其他异常情况，我们想做一个本地缓存，当时目前`agollo.Start()`无法判断启动结果如何（`agollo.GetApolloConfigCache().EntryCount()`的写法感觉不优雅），所以既然`notifySyncConfigServices`会返回`error`，干脆直接扔给client用户去处理。
