### PR TITLE
增加数组的写入和读取，完成单独key的事件处理

### DIFF
--- a/agcache/cache.go
+++ b/agcache/cache.go
@@ -2,11 +2,11 @@ package agcache
 
 //CacheInterface 自定义缓存组件接口
 type CacheInterface interface {
-	Set(key string, value []byte, expireSeconds int) (err error)
+	Set(key string, value interface{}, expireSeconds int) (err error)
 
 	EntryCount() (entryCount int64)
 
-	Get(key string) (value []byte, err error)
+	Get(key string) (value interface{}, err error)
 
 	Del(key string) (affected bool)
 

--- a/agcache/memory/memory.go
+++ b/agcache/memory/memory.go
@@ -2,10 +2,10 @@ package memory
 
 import (
 	"errors"
-	"sync"
-
 	"github.com/zouyx/agollo/v3/agcache"
 	"github.com/zouyx/agollo/v3/extension"
+	"sync"
+	"sync/atomic"
 )
 
 func init() {
@@ -15,31 +15,29 @@ func init() {
 //DefaultCache 默认缓存
 type DefaultCache struct {
 	defaultCache sync.Map
+	count int64
 }
 
 //Set 获取缓存
-func (d *DefaultCache) Set(key string, value []byte, expireSeconds int) (err error) {
+func (d *DefaultCache) Set(key string, value interface{}, expireSeconds int) (err error) {
 	d.defaultCache.Store(key, value)
+	atomic.AddInt64(&d.count, int64(1))
 	return nil
 }
 
 //EntryCount 获取实体数量
 func (d *DefaultCache) EntryCount() (entryCount int64) {
-	count := int64(0)
-	d.defaultCache.Range(func(key, value interface{}) bool {
-		count++
-		return true
-	})
-	return count
+	c := atomic.LoadInt64(&d.count)
+	return c
 }
 
 //Get 获取缓存
-func (d *DefaultCache) Get(key string) (value []byte, err error) {
+func (d *DefaultCache) Get(key string) (value interface{}, err error) {
 	v, ok := d.defaultCache.Load(key)
 	if !ok {
 		return nil, errors.New("load default cache fail")
 	}
-	return v.([]byte), nil
+	return v, nil
 }
 
 //Range 遍历缓存
@@ -50,12 +48,14 @@ func (d *DefaultCache) Range(f func(key, value interface{}) bool) {
 //Del 删除缓存
 func (d *DefaultCache) Del(key string) (affected bool) {
 	d.defaultCache.Delete(key)
+	atomic.AddInt64(&d.count, int64(-1))
 	return true
 }
 
 //Clear 清除所有缓存
 func (d *DefaultCache) Clear() {
 	d.defaultCache = sync.Map{}
+	atomic.StoreInt64(&d.count, int64(0))
 }
 
 //DefaultCacheFactory 构造默认缓存组件工厂类

--- a/agcache/memory/memory_test.go
+++ b/agcache/memory/memory_test.go
@@ -13,11 +13,11 @@ func init() {
 	factory := &DefaultCacheFactory{}
 	testDefaultCache = factory.Create()
 
-	testDefaultCache.Set("a", []byte("b"), 100)
+	_ = testDefaultCache.Set("a", "b", 100)
 }
 
 func TestDefaultCache_Set(t *testing.T) {
-	err := testDefaultCache.Set("k", []byte("c"), 100)
+	err := testDefaultCache.Set("k", "c", 100)
 	Assert(t, err, NilVal())
 	Assert(t, int64(2), Equal(testDefaultCache.EntryCount()))
 }
@@ -40,7 +40,7 @@ func TestDefaultCache_Del(t *testing.T) {
 func TestDefaultCache_Get(t *testing.T) {
 	value, err := testDefaultCache.Get("a")
 	Assert(t, err, NilVal())
-	Assert(t, string(value), Equal("b"))
+	Assert(t, value, Equal("b"))
 }
 
 func TestDefaultCache_Clear(t *testing.T) {

--- a/component/notify/change_event_test.go
+++ b/component/notify/change_event_test.go
@@ -30,15 +30,15 @@ func (c *CustomChangeListener) OnChange(changeEvent *storage.ChangeEvent) {
 	Assert(c.t, "application", Equal(changeEvent.Namespace))
 
 	Assert(c.t, "string", Equal(changeEvent.Changes["string"].NewValue))
-	Assert(c.t, "", Equal(changeEvent.Changes["string"].OldValue))
+	Assert(c.t, nil, Equal(changeEvent.Changes["string"].OldValue))
 	Assert(c.t, storage.ADDED, Equal(changeEvent.Changes["string"].ChangeType))
 
 	Assert(c.t, "value1", Equal(changeEvent.Changes["key1"].NewValue))
-	Assert(c.t, "", Equal(changeEvent.Changes["key2"].OldValue))
+	Assert(c.t, nil, Equal(changeEvent.Changes["key2"].OldValue))
 	Assert(c.t, storage.ADDED, Equal(changeEvent.Changes["key1"].ChangeType))
 
 	Assert(c.t, "value2", Equal(changeEvent.Changes["key2"].NewValue))
-	Assert(c.t, "", Equal(changeEvent.Changes["key2"].OldValue))
+	Assert(c.t, nil, Equal(changeEvent.Changes["key2"].OldValue))
 	Assert(c.t, storage.ADDED, Equal(changeEvent.Changes["key2"].ChangeType))
 }
 

--- a/component/notify/componet_notify.go
+++ b/component/notify/componet_notify.go
@@ -283,7 +283,6 @@ func createApolloConfigWithJSON(b []byte) (*env.ApolloConfig, error) {
 	if parser == nil {
 		return apolloConfig, nil
 	}
-
 	m, err := parser.Parse(apolloConfig.Configurations[defaultContentKey])
 	if err != nil {
 		log.Debug("GetContent fail ! error:", err)

--- a/env/apollo_config.go
+++ b/env/apollo_config.go
@@ -57,8 +57,9 @@ type ApolloConnConfig struct {
 //ApolloConfig apollo配置
 type ApolloConfig struct {
 	ApolloConnConfig
-	Configurations map[string]string `json:"configurations"`
+	Configurations map[string]interface{} `json:"configurations"`
 }
+
 
 //Init 初始化
 func (a *ApolloConfig) Init(appID string, cluster string, namespace string) {
@@ -66,3 +67,4 @@ func (a *ApolloConfig) Init(appID string, cluster string, namespace string) {
 	a.Cluster = cluster
 	a.NamespaceName = namespace
 }
+

--- a/env/file/json/json_test.go
+++ b/env/file/json/json_test.go
@@ -20,7 +20,8 @@ func TestJSONFileHandler_WriteConfigFile(t *testing.T) {
   "namespaceName": "application",
   "configurations": {
     "key1":"value1",
-    "key2":"value2"
+    "key2":"value2",
+    "test": [1, 2]
   },
   "releaseKey": "20170430092936-dee2d58e74515ff3"
 }`
@@ -41,7 +42,8 @@ func TestJSONFileHandler_LoadConfigFile(t *testing.T) {
   "namespaceName": "application",
   "configurations": {
     "key1":"value1",
-    "key2":"value2"
+    "key2":"value2",
+    "test": [1, 2]
   },
   "releaseKey": "20170430092936-dee2d58e74515ff3"
 }`

--- a/env/file/json/raw.go
+++ b/env/file/json/raw.go
@@ -32,9 +32,11 @@ func writeWithRaw(config *env.ApolloConfig, configDir string) error {
 		return e
 	}
 	defer file.Close()
-	_, e = file.WriteString(config.Configurations["content"])
-	if e != nil {
-		return e
+	if config.Configurations["content"] != nil {
+		_, e = file.WriteString(config.Configurations["content"].(string))
+		if e != nil {
+			return e
+		}
 	}
 	return nil
 }

--- a/env/file/json/raw_test.go
+++ b/env/file/json/raw_test.go
@@ -17,7 +17,8 @@ func TestRawHandler_WriteConfigFile(t *testing.T) {
   "namespaceName": "application.json",
   "configurations": {
     "key1":"value1",
-    "key2":"value2"
+    "key2":"value2",
+    "test": ["a", "b"]
   },
   "releaseKey": "20170430092936-dee2d58e74515ff3"
 }`

--- a/env/file/json/raw_test.go
+++ b/env/file/json/raw_test.go
@@ -31,6 +31,28 @@ func TestRawHandler_WriteConfigFile(t *testing.T) {
 	Assert(t, e, NilVal())
 }
 
+func TestRawHandler_WriteConfigFileWithContent(t *testing.T) {
+	extension.SetFileHandler(&rawFileHandler{})
+	configPath := ""
+	jsonStr := `{
+  "appId": "100004458",
+  "cluster": "default",
+  "namespaceName": "application.json",
+  "configurations": {
+    "content":"a: value1"
+  },
+  "releaseKey": "20170430092936-dee2d58e74515ff3"
+}`
+
+	config, err := createApolloConfigWithJSON([]byte(jsonStr))
+	Assert(t, err, NilVal())
+	os.Remove(extension.GetFileHandler().GetConfigFile(configPath, config.NamespaceName))
+
+	Assert(t, err, NilVal())
+	e := extension.GetFileHandler().WriteConfigFile(config, configPath)
+	Assert(t, e, NilVal())
+}
+
 func TestGetRawFileHandler(t *testing.T) {
 	handler := GetRawFileHandler()
 	Assert(t, handler, NotNilVal())

--- a/extension/cache_test.go
+++ b/extension/cache_test.go
@@ -22,7 +22,7 @@ type defaultCache struct {
 }
 
 //Set 获取缓存
-func (d *defaultCache) Set(key string, value []byte, expireSeconds int) (err error) {
+func (d *defaultCache) Set(key string, value interface{}, expireSeconds int) (err error) {
 	d.defaultCache.Store(key, value)
 	return nil
 }
@@ -38,7 +38,7 @@ func (d *defaultCache) EntryCount() (entryCount int64) {
 }
 
 //Get 获取缓存
-func (d *defaultCache) Get(key string) (value []byte, err error) {
+func (d *defaultCache) Get(key string) (value interface{}, err error) {
 	v, ok := d.defaultCache.Load(key)
 	if !ok {
 		return nil, errors.New("load default cache fail")

--- a/extension/format_parser_test.go
+++ b/extension/format_parser_test.go
@@ -12,7 +12,7 @@ type TestParser struct {
 }
 
 // Parse 内存内容默认转换器
-func (d *TestParser) Parse(s string) (map[string]string, error) {
+func (d *TestParser) Parse(s interface{}) (map[string]interface{}, error) {
 	return nil, nil
 }
 

--- a/repository.go
+++ b/repository.go
@@ -123,6 +123,34 @@ func GetBoolValue(key string, defaultValue bool) bool {
 	return b
 }
 
+//GetStringSliceValue 获取[]string 配置值
+func GetStringSliceValue(key string, defaultValue []string) []string {
+	value := getConfigValue(key)
+
+	if value == nil {
+		return defaultValue
+	}
+	s, ok := value.([]string)
+	if !ok {
+		return defaultValue
+	}
+	return s
+}
+
+//GetIntSliceValue 获取[]int 配置值
+func GetIntSliceValue(key string, defaultValue []int) []int {
+	value := getConfigValue(key)
+
+	if value == nil {
+		return defaultValue
+	}
+	s, ok := value.([]int)
+	if !ok {
+		return defaultValue
+	}
+	return s
+}
+
 func getConfigValue(key string) interface{} {
 	cache := GetDefaultConfigCache()
 	if cache == nil {
@@ -135,5 +163,5 @@ func getConfigValue(key string) interface{} {
 		return utils.Empty
 	}
 
-	return string(value)
+	return value
 }

--- a/repository_test.go
+++ b/repository_test.go
@@ -21,8 +21,8 @@ const testDefaultNamespace = "application"
 func init() {
 }
 
-func createMockApolloConfig(expireTime int) map[string]string {
-	configs := make(map[string]string, 0)
+func createMockApolloConfig(expireTime int) map[string]interface{}{
+	configs := make(map[string]interface{}, 0)
 	//string
 	configs["string"] = "value"
 	//int
@@ -31,6 +31,11 @@ func createMockApolloConfig(expireTime int) map[string]string {
 	configs["float"] = "190.3"
 	//bool
 	configs["bool"] = "true"
+	//string slice
+	configs["stringSlice"] = []string{"1", "2"}
+
+	//int slice
+	configs["intSlice"] = []int{1, 2}
 
 	storage.UpdateApolloConfigCache(configs, expireTime, storage.GetDefaultNamespace())
 
@@ -74,6 +79,46 @@ func TestGetIntValue(t *testing.T) {
 
 	//error type
 	v = GetIntValue("float", defaultValue)
+
+	Assert(t, defaultValue, Equal(v))
+}
+
+func TestGetIntSliceValue(t *testing.T) {
+	createMockApolloConfig(120)
+	defaultValue := []int{100}
+
+	//test default
+	v := GetIntSliceValue("joe", defaultValue)
+
+	Assert(t, defaultValue, Equal(v))
+
+	//normal value
+	v = GetIntSliceValue("intSlice", defaultValue)
+
+	Assert(t, []int{1, 2}, Equal(v))
+
+	//error type
+	v = GetIntSliceValue("float", defaultValue)
+
+	Assert(t, defaultValue, Equal(v))
+}
+
+func TestGetStringSliceValue(t *testing.T) {
+	createMockApolloConfig(120)
+	defaultValue := []string{"100"}
+
+	//test default
+	v := GetStringSliceValue("joe", defaultValue)
+
+	Assert(t, defaultValue, Equal(v))
+
+	//normal value
+	v = GetStringSliceValue("stringSlice", defaultValue)
+
+	Assert(t, []string{"1", "2"}, Equal(v))
+
+	//error type
+	v = GetStringSliceValue("float", defaultValue)
 
 	Assert(t, defaultValue, Equal(v))
 }
@@ -150,7 +195,7 @@ func TestAutoSyncConfigServicesNormal2NotModified(t *testing.T) {
 	defaultConfigCache := GetDefaultConfigCache()
 
 	defaultConfigCache.Range(func(key, value interface{}) bool {
-		Assert(t, string(value.([]byte)), NotNilVal())
+		Assert(t, value, NotNilVal())
 		return true
 	})
 

--- a/start.go
+++ b/start.go
@@ -64,6 +64,11 @@ func SetLogger(loggerInterface log.LoggerInterface) {
 	}
 }
 
+//UseEventDispatch  添加为某些key分发event功能
+func UseEventDispatch() {
+	storage.UseEventDispatch()
+}
+
 //SetCache 设置自定义cache组件
 func SetCache(cacheFactory agcache.CacheFactory) {
 	if cacheFactory != nil {

--- a/start_test.go
+++ b/start_test.go
@@ -177,6 +177,12 @@ func TestSetLogger(t *testing.T) {
 	Assert(t, log.Logger, Equal(logger))
 }
 
+func TestUseEventDispatch(t *testing.T) {
+	UseEventDispatch()
+	l := storage.GetChangeListeners()
+	Assert(t, l.Len(), Equal(1))
+}
+
 func TestSetCache(t *testing.T) {
 	defaultCacheFactory := &memory.DefaultCacheFactory{}
 	SetCache(defaultCacheFactory)

--- a/storage/change_event.go
+++ b/storage/change_event.go
@@ -34,8 +34,8 @@ type ChangeEvent struct {
 }
 
 type ConfigChange struct {
-	OldValue   string
-	NewValue   string
+	OldValue   interface{}
+	NewValue   interface{}
 	ChangeType ConfigChangeType
 }
 
@@ -79,7 +79,7 @@ func pushChangeEvent(event *ChangeEvent) {
 }
 
 //create modify config change
-func createModifyConfigChange(oldValue string, newValue string) *ConfigChange {
+func createModifyConfigChange(oldValue interface{}, newValue interface{}) *ConfigChange {
 	return &ConfigChange{
 		OldValue:   oldValue,
 		NewValue:   newValue,
@@ -88,7 +88,7 @@ func createModifyConfigChange(oldValue string, newValue string) *ConfigChange {
 }
 
 //create add config change
-func createAddConfigChange(newValue string) *ConfigChange {
+func createAddConfigChange(newValue interface{}) *ConfigChange {
 	return &ConfigChange{
 		NewValue:   newValue,
 		ChangeType: ADDED,
@@ -96,7 +96,7 @@ func createAddConfigChange(newValue string) *ConfigChange {
 }
 
 //create delete config change
-func createDeletedConfigChange(oldValue string) *ConfigChange {
+func createDeletedConfigChange(oldValue interface{}) *ConfigChange {
 	return &ConfigChange{
 		OldValue:   oldValue,
 		ChangeType: DELETED,

--- a/storage/event_dispatch.go
+++ b/storage/event_dispatch.go
@@ -1,0 +1,159 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"github.com/zouyx/agollo/v3/component/log"
+	"regexp"
+)
+
+const (
+	fmtInvalidKey        = "invalid key format for key %s"
+)
+
+var (
+	//ErrNilListener 为没有找到listener的错误
+	ErrNilListener = errors.New("nil listener")
+)
+
+var (
+	eventDispatch *Dispatcher
+)
+
+// Event generated when any config changes
+type Event struct {
+	EventType ConfigChangeType
+	Key       string
+	Value     interface{}
+}
+
+// Listener All Listener should implement this Interface
+type Listener interface {
+	Event(event *Event)
+}
+
+//Dispatcher is the observer
+type Dispatcher struct {
+	listeners map[string][]Listener
+}
+
+// UseEventDispatch 用于开启事件分发功能
+func UseEventDispatch() {
+	eventDispatch = new(Dispatcher)
+	eventDispatch.listeners = make(map[string][]Listener)
+	AddChangeListener(eventDispatch)
+}
+
+// RegisterListener 为某些key注释Listener
+func RegisterListener(listener Listener, keys ...string) error {return eventDispatch.RegisterListener(listener, keys...)}
+
+// RegisterListener 是为某些key注释Listener的方法
+func (d *Dispatcher) RegisterListener(listenerObject Listener, keys ...string) error {
+	log.Infof("start add  key %v add listener", keys)
+	if listenerObject == nil {
+		return ErrNilListener
+	}
+
+	for _, key := range keys {
+		if invalidKey(key) {
+			return fmt.Errorf(fmtInvalidKey, key)
+		}
+
+		listenerList, ok := d.listeners[key]
+		if !ok {
+			d.listeners[key] = make([]Listener, 0)
+		}
+
+		for _, listener := range listenerList {
+			if listener == listenerObject {
+				log.Infof("key %s had listener", key)
+				return nil
+			}
+		}
+		// append new listener
+		listenerList = append(listenerList, listenerObject)
+		d.listeners[key] = listenerList
+	}
+	return nil
+}
+
+func invalidKey(key string) bool {
+	_, err := regexp.Compile(key)
+	if err != nil {
+		return true
+	}
+	return false
+}
+
+// UnRegisterListener 为某些key注释Listener
+func UnRegisterListener(listenerObj Listener, keys ...string) error {return eventDispatch.UnRegisterListener(listenerObj, keys...)}
+
+// UnRegisterListener 用于为某些key注释Listener
+func (d *Dispatcher) UnRegisterListener(listenerObj Listener, keys ...string) error {
+	if listenerObj == nil {
+		return ErrNilListener
+	}
+
+	for _, key := range keys {
+		listenerList, ok := d.listeners[key]
+		if !ok {
+			continue
+		}
+
+		newListenerList := make([]Listener, 0)
+		// remove listener
+		for _, listener := range listenerList {
+			if listener == listenerObj {
+				continue
+			}
+			newListenerList = append(newListenerList, listener)
+		}
+
+		// assign latest listener list
+		d.listeners[key] = newListenerList
+	}
+	return nil
+}
+
+//OnChange 实现Apollo的ChangeEvent处理
+func (d *Dispatcher) OnChange(changeEvent *ChangeEvent){
+	if changeEvent == nil {
+		return
+	}
+	log.Logger.Infof("get change event for namespace %s", changeEvent.Namespace)
+	for key, event := range changeEvent.Changes {
+		d.dispatchEvent(key, event)
+	}
+}
+
+func (d *Dispatcher) dispatchEvent(eventKey string, event *ConfigChange) {
+	for regKey, listenerList := range d.listeners {
+		matched, err := regexp.MatchString(regKey, eventKey)
+		if err != nil {
+			log.Logger.Errorf("regular expression for key %s error %s", eventKey, err)
+			continue
+		}
+		if matched {
+			for _, listener := range listenerList {
+				log.Logger.Info("event generated for %s key %s", regKey, eventKey)
+				go listener.Event(convertToEvent(eventKey, event))
+			}
+		}
+	}
+}
+
+func convertToEvent(key string, event *ConfigChange) *Event {
+	e := &Event{
+		EventType: event.ChangeType,
+		Key: key,
+	}
+	switch event.ChangeType {
+	case ADDED:
+		e.Value = event.NewValue
+	case MODIFIED:
+		e.Value = event.NewValue
+	case DELETED:
+		e.Value = event.OldValue
+	}
+	return e
+}

--- a/storage/event_dispatch_test.go
+++ b/storage/event_dispatch_test.go
@@ -1,0 +1,121 @@
+package storage
+
+import (
+	. "github.com/tevid/gohamcrest"
+	"sync"
+	"testing"
+	"time"
+)
+
+
+type CustomListener struct {
+	l sync.Mutex
+	Keys map[string]interface{}
+}
+
+func (t *CustomListener) Event(event *Event) {
+	t.l.Lock()
+	defer t.l.Unlock()
+	t.Keys[event.Key] = event.Value
+}
+
+func createChangeEvent() *ChangeEvent {
+	addConfig := createAddConfigChange("new")
+	deleteConfig := createDeletedConfigChange("old")
+	modifyConfig := createModifyConfigChange("old", "new")
+	changes := make(map[string]*ConfigChange)
+	changes["add"] = addConfig
+	changes["adx"] = addConfig
+	changes["delete"] = deleteConfig
+	changes["modify"] = modifyConfig
+	cEvent := &ChangeEvent{
+		"a",
+		changes,
+	}
+	return cEvent
+}
+
+func TestUseDispatch(t *testing.T) {
+	UseEventDispatch()
+	Assert(t, changeListeners.Len(), Equal(1))
+	RemoveChangeListener(eventDispatch)
+}
+
+func TestDispatch(t *testing.T) {
+	UseEventDispatch()
+	l := &CustomListener{
+		Keys: make(map[string]interface{}, 0),
+	}
+	err := RegisterListener(l, "add", "delete")
+	Assert(t, err, NilVal())
+	Assert(t, len(eventDispatch.listeners), Equal(2))
+	cEvent := createChangeEvent()
+	pushChangeEvent(cEvent)
+	time.Sleep(1 * time.Second)
+	Assert(t, len(l.Keys), Equal(2))
+	v, ok := l.Keys["add"]
+	Assert(t, v, Equal("new"))
+	Assert(t, ok, Equal(true))
+	v, ok = l.Keys["delete"]
+	Assert(t, ok, Equal(true))
+	Assert(t, v, Equal("old"))
+	_, ok = l.Keys["modify"]
+	Assert(t, ok, Equal(false))
+}
+
+func TestRegDispatch(t *testing.T) {
+	UseEventDispatch()
+	err := RegisterListener(nil, "ad.*")
+	Assert(t, err, NotNilVal())
+	l := &CustomListener{
+		Keys: make(map[string]interface{}, 0),
+	}
+	err = RegisterListener(l, "ad.*")
+	Assert(t, err, NilVal())
+	Assert(t, len(eventDispatch.listeners), Equal(1))
+	cEvent := createChangeEvent()
+	pushChangeEvent(cEvent)
+	time.Sleep(1 * time.Second)
+	Assert(t, len(l.Keys), Equal(2))
+	v, ok := l.Keys["add"]
+	Assert(t, v, Equal("new"))
+	Assert(t, ok, Equal(true))
+	v, ok = l.Keys["adx"]
+	Assert(t, v, Equal("new"))
+	Assert(t, ok, Equal(true))
+}
+
+func TestDuplicateRegDispatch(t *testing.T) {
+	UseEventDispatch()
+	l := &CustomListener{
+		Keys: make(map[string]interface{}, 0),
+	}
+	err := RegisterListener(l, "ad.*")
+	Assert(t, err, NilVal())
+	Assert(t, len(eventDispatch.listeners), Equal(1))
+	Assert(t, len(eventDispatch.listeners["ad.*"]), Equal(1))
+
+	err = RegisterListener(l, "ad.*")
+	Assert(t, err, NilVal())
+	Assert(t, len(eventDispatch.listeners), Equal(1))
+	Assert(t, len(eventDispatch.listeners["ad.*"]), Equal(1))
+}
+
+func TestUnRegisterListener(t *testing.T) {
+	UseEventDispatch()
+	err := RegisterListener(nil, "ad.*")
+	Assert(t, err, NotNilVal())
+	l := &CustomListener{
+		Keys: make(map[string]interface{}, 0),
+	}
+	err = RegisterListener(l, "ad.*")
+	Assert(t, err, NilVal())
+	Assert(t, len(eventDispatch.listeners), Equal(1))
+	Assert(t, len(eventDispatch.listeners["ad.*"]), Equal(1))
+
+	err = UnRegisterListener(l, "ad.*")
+	Assert(t, err, NilVal())
+	Assert(t, len(eventDispatch.listeners), Equal(1))
+	Assert(t, len(eventDispatch.listeners["ad.*"]), Equal(0))
+
+}

--- a/storage/repository_test.go
+++ b/storage/repository_test.go
@@ -18,14 +18,25 @@ import (
 func init() {
 }
 
+func creatTestApolloConfig(configurations map[string]interface{}, namespace string) {
+	apolloConfig := &env.ApolloConfig{}
+	apolloConfig.NamespaceName = namespace
+	apolloConfig.AppID = "test"
+	apolloConfig.Cluster = "dev"
+	apolloConfig.Configurations = configurations
+	UpdateApolloConfig(apolloConfig, true)
+
+}
+
 func TestUpdateApolloConfigNull(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
-	configurations := make(map[string]string)
+	configurations := make(map[string]interface{})
 	configurations["string"] = "string"
 	configurations["int"] = "1"
 	configurations["float"] = "1"
 	configurations["bool"] = "true"
+	configurations["slice"] = []int{1, 2}
 
 	apolloConfig := &env.ApolloConfig{}
 	apolloConfig.NamespaceName = defaultNamespace
@@ -42,7 +53,7 @@ func TestUpdateApolloConfigNull(t *testing.T) {
 	Assert(t, apolloConfig.AppID, Equal(config.AppID))
 	Assert(t, apolloConfig.Cluster, Equal(config.Cluster))
 	Assert(t, "", Equal(config.ReleaseKey))
-	Assert(t, len(apolloConfig.Configurations), Equal(4))
+	Assert(t, len(apolloConfig.Configurations), Equal(5))
 
 }
 
@@ -57,21 +68,30 @@ func TestGetDefaultNamespace(t *testing.T) {
 }
 
 func TestGetConfig(t *testing.T) {
-	config := GetConfig(defaultNamespace)
+	configurations := make(map[string]interface{})
+	configurations["string"] = "string2"
+	configurations["int"] = "2"
+	configurations["float"] = "1"
+	configurations["bool"] = "false"
+	configurations["sliceString"] = []string{"1", "2", "3"}
+	configurations["sliceInt"] = []int{1, 2, 3}
+	configurations["sliceInter"] = []interface{}{1, "2", 3}
+	creatTestApolloConfig(configurations, "test")
+	config := GetConfig("test")
 	Assert(t, config, NotNilVal())
 
 	//string
 	s := config.GetStringValue("string", "s")
-	Assert(t, s, Equal("string"))
+	Assert(t, s, Equal(configurations["string"]))
 
 	s = config.GetStringValue("s", "s")
 	Assert(t, s, Equal("s"))
 
 	//int
-	i := config.GetIntValue("int", 2)
-	Assert(t, i, Equal(int(1)))
-	i = config.GetIntValue("i", 2)
-	Assert(t, i, Equal(int(2)))
+	i := config.GetIntValue("int", 3)
+	Assert(t, i, Equal(2))
+	i = config.GetIntValue("i", 3)
+	Assert(t, i, Equal(3))
 
 	//float
 	f := config.GetFloatValue("float", 2)
@@ -80,23 +100,37 @@ func TestGetConfig(t *testing.T) {
 	Assert(t, f, Equal(float64(2)))
 
 	//bool
-	b := config.GetBoolValue("bool", false)
-	Assert(t, b, Equal(true))
+	b := config.GetBoolValue("bool", true)
+	Assert(t, b, Equal(false))
 
 	b = config.GetBoolValue("b", false)
 	Assert(t, b, Equal(false))
+
+	slice := config.GetStringSliceValue("sliceString")
+	Assert(t, slice, Equal([]string{"1", "2", "3"}))
+
+	sliceInt := config.GetIntSliceValue("sliceInt")
+	Assert(t, sliceInt, Equal([]int{1, 2, 3}))
+
+	sliceInter := config.GetSliceValue("sliceInter")
+	Assert(t, sliceInter, Equal([]interface{}{1, "2", 3}))
 
 	//content
 	content := config.GetContent()
 	hasFloat := strings.Contains(content, "float=1")
 	Assert(t, hasFloat, Equal(true))
 
-	hasInt := strings.Contains(content, "int=1")
+	hasInt := strings.Contains(content, "int=2")
 	Assert(t, hasInt, Equal(true))
 
-	hasString := strings.Contains(content, "string=string")
+	hasString := strings.Contains(content, "string=string2")
 	Assert(t, hasString, Equal(true))
 
-	hasBool := strings.Contains(content, "bool=true")
+	hasBool := strings.Contains(content, "bool=false")
 	Assert(t, hasBool, Equal(true))
+
+	hasSlice := strings.Contains(content, "sliceString=[1 2 3]")
+	Assert(t, hasSlice, Equal(true))
+	hasSlice = strings.Contains(content, "sliceInt=[1 2 3]")
+	Assert(t, hasSlice, Equal(true))
 }

--- a/utils/parse/normal/parser.go
+++ b/utils/parse/normal/parser.go
@@ -14,6 +14,6 @@ type Parser struct {
 }
 
 // Parse 内存内容默认转换器
-func (d *Parser) Parse(configContent string) (map[string]string, error) {
+func (d *Parser) Parse(configContent interface{}) (map[string]interface{}, error) {
 	return nil, nil
 }

--- a/utils/parse/parser.go
+++ b/utils/parse/parser.go
@@ -2,5 +2,5 @@ package parse
 
 //ContentParser 内容转换
 type ContentParser interface {
-	Parse(configContent string) (map[string]string, error)
+	Parse(configContent interface{}) (map[string]interface{}, error)
 }

--- a/utils/parse/properties/parser.go
+++ b/utils/parse/properties/parser.go
@@ -14,6 +14,6 @@ type Parser struct {
 }
 
 // Parse 内存内容=>properties文件转换器
-func (d *Parser) Parse(configContent string) (map[string]string, error) {
+func (d *Parser) Parse(configContent interface{}) (map[string]interface{}, error) {
 	return nil, nil
 }

--- a/utils/parse/yaml/parser.go
+++ b/utils/parse/yaml/parser.go
@@ -11,8 +11,8 @@ import (
 var vp = viper.New()
 
 func init() {
-	extension.AddFormatParser(constant.YML, &Parser{})
-	vp.SetConfigType("yml")
+	extension.AddFormatParser(constant.YAML, &Parser{})
+	vp.SetConfigType("yaml")
 }
 
 // Parser properties转换器

--- a/utils/parse/yaml/parser.go
+++ b/utils/parse/yaml/parser.go
@@ -1,4 +1,4 @@
-package yml
+package yaml
 
 import (
 	"bytes"

--- a/utils/parse/yaml/parser_test.go
+++ b/utils/parse/yaml/parser_test.go
@@ -1,0 +1,33 @@
+package yml
+
+import (
+	"github.com/zouyx/agollo/v3/utils/parse"
+	"testing"
+
+	. "github.com/tevid/gohamcrest"
+)
+
+var (
+	ymlParser parse.ContentParser = &Parser{}
+)
+
+func TestYMLParser(t *testing.T) {
+	s, err := ymlParser.Parse(`
+a:
+    a1: a1
+b:
+    b1: b1
+c:
+    c1: c1
+d:
+    d1: d1
+e:  
+    e1: e1`)
+	Assert(t, err, NilVal())
+
+	Assert(t, s["a.a1"], Equal("a1"))
+
+	Assert(t, s["b.b1"], Equal("b1"))
+
+	Assert(t, s["c.c1"], Equal("c1"))
+}

--- a/utils/parse/yaml/parser_test.go
+++ b/utils/parse/yaml/parser_test.go
@@ -1,6 +1,7 @@
-package yml
+package yaml
 
 import (
+	"github.com/zouyx/agollo/v3/utils"
 	"github.com/zouyx/agollo/v3/utils/parse"
 	"testing"
 
@@ -8,11 +9,11 @@ import (
 )
 
 var (
-	ymlParser parse.ContentParser = &Parser{}
+	yamlParser parse.ContentParser = &Parser{}
 )
 
-func TestYMLParser(t *testing.T) {
-	s, err := ymlParser.Parse(`
+func TestYAMLParser(t *testing.T) {
+	s, err := yamlParser.Parse(`
 a:
     a1: a1
 b:
@@ -30,4 +31,18 @@ e:
 	Assert(t, s["b.b1"], Equal("b1"))
 
 	Assert(t, s["c.c1"], Equal("c1"))
+
 }
+
+func TestYAMLParserOnException(t *testing.T) {
+	s, err := yamlParser.Parse(utils.Empty)
+	Assert(t, err, NilVal())
+	Assert(t, s, NilVal())
+	s, err = yamlParser.Parse(0)
+	Assert(t, err, NilVal())
+	Assert(t, s, NilVal())
+
+	m := convertToMap(nil)
+	Assert(t, m, NilVal())
+}
+

--- a/utils/parse/yml/parser_test.go
+++ b/utils/parse/yml/parser_test.go
@@ -1,6 +1,7 @@
 package yml
 
 import (
+	"github.com/zouyx/agollo/v3/utils"
 	"github.com/zouyx/agollo/v3/utils/parse"
 	"testing"
 
@@ -30,4 +31,16 @@ e:
 	Assert(t, s["b.b1"], Equal("b1"))
 
 	Assert(t, s["c.c1"], Equal("c1"))
+}
+
+func TestYMLParserOnException(t *testing.T) {
+	s, err := ymlParser.Parse(utils.Empty)
+	Assert(t, err, NilVal())
+	Assert(t, s, NilVal())
+	s, err = ymlParser.Parse(0)
+	Assert(t, err, NilVal())
+	Assert(t, s, NilVal())
+
+	m := convertToMap(nil)
+	Assert(t, m, NilVal())
 }


### PR DESCRIPTION
1. 增加yaml后缀的格式解析，对接apollo的类型
2. 实现list类型配置的解析写入和读取
3. 修改了OnChange事件保存的value类型为interface
4. 提供为某些key注册Listener，从而实现对某些key进行事件处理；注册支持模糊匹配