### PR TITLE
extension相关初始化提到 init 中处理

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Agollo - Go Client for Apollo
 方便Golang接入配置中心框架 [Apollo](https://github.com/ctripcorp/apollo) 所开发的Golang版本客户端。
 
 # Features
+* 支持多 IP、AppID、namespace
 * 实时同步配置
 * 灰度配置
 * 延迟加载（运行时）namespace

--- a/client.go
+++ b/client.go
@@ -42,16 +42,7 @@ import (
 	"strconv"
 )
 
-var syncApolloConfig = remote.CreateSyncApolloConfig()
-
-// Client apollo 客户端实例
-type Client struct {
-	initAppConfigFunc func() (*config.AppConfig, error)
-	appConfig         *config.AppConfig
-	cache             *storage.Cache
-}
-
-func create() *Client {
+func init() {
 	extension.SetCacheFactory(&memory.DefaultCacheFactory{})
 	extension.SetLoadBalance(&roundrobin.RoundRobin{})
 	extension.SetFileHandler(&jsonFile.FileHandler{})
@@ -62,9 +53,20 @@ func create() *Client {
 	extension.AddFormatParser(constant.Properties, &properties.Parser{})
 	extension.AddFormatParser(constant.YML, &yml.Parser{})
 	extension.AddFormatParser(constant.YAML, &yaml.Parser{})
+}
+
+var syncApolloConfig = remote.CreateSyncApolloConfig()
+
+// Client apollo 客户端实例
+type Client struct {
+	initAppConfigFunc func() (*config.AppConfig, error)
+	appConfig         *config.AppConfig
+	cache             *storage.Cache
+}
+
+func create() *Client {
 
 	appConfig := env.InitFileConfig()
-
 	return &Client{
 		appConfig: appConfig,
 	}


### PR DESCRIPTION
你好，当我使用 extension.AddFormatParser(constant.YAML, &configParser{})时，发现 agollo.create 中会覆盖掉 yaml的解析。
