### PR TITLE
[Fix]: 当同步获取配置失败时增加读取本地配置文件 

### DIFF
--- a/component/remote/sync.go
+++ b/component/remote/sync.go
@@ -96,11 +96,11 @@ func (a *syncApolloConfig) Sync(appConfig *config.AppConfig) []*config.ApolloCon
 	configs := make([]*config.ApolloConfig, 0, 8)
 	config.SplitNamespaces(appConfig.NamespaceName, func(namespace string) {
 		apolloConfig := a.SyncWithNamespace(namespace, appConfig)
-		if apolloConfig == nil {
+		if apolloConfig != nil {
+			configs = append(configs, apolloConfig)
 			return
 		}
-
-		configs = append(configs, apolloConfig)
+		configs = append(configs, loadBackupConfig(appConfig.NamespaceName, appConfig)...)
 	})
 	return configs
 }


### PR DESCRIPTION
* 当同步获取配置失败时增加读取本地配置文件  fix #148 