### PR TITLE
修改当更新配置失败时会导致后续再也无法更新的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,49 @@ Agollo - Go Client for Apollo
  
 # Usage
 
+## 快速入门
+
+### 导入 agollo
+```
+go get -u github.com/zouyx/agollo/v4@latest
+```
+
+### 启动 agollo
+```
+package main
+
+import (
+	"fmt"
+	"github.com/zouyx/agollo/v4"
+	"github.com/zouyx/agollo/v4/env/config"
+)
+
+func main(){
+           c := &config.AppConfig{
+		AppID:          "testApplication_yang",
+		Cluster:        "dev",
+		IP:             "http://106.54.227.205:8080",
+		NamespaceName:  "dubbo",
+		IsBackupConfig: true,
+		Secret:         "6ce3ff7e96a24335a9634fe9abca6d51",
+	}
+	agollo.SetLogger(&DefaultLogger{})
+
+	client,err:=agollo.StartWithConfig(func() (*config.AppConfig, error) {
+		return c, nil
+	})
+    fmt.Println("初始化Apollo配置成功")
+    
+    //Use your apollo key to test
+    cache := client.GetConfigCache(c.NamespaceName)
+    value,_ := client.Get("key")
+    fmt.Println(value)
+}
+```
+
+
+## 更多用法
+
 ***使用Demo*** ：[agollo_demo](https://github.com/zouyx/agollo_demo)
 
 ***其他语言*** ： [agollo-agent](https://github.com/zouyx/agollo-agent.git) 做本地agent接入，如：PHP

--- a/env/config/config.go
+++ b/env/config/config.go
@@ -157,6 +157,13 @@ func (n *notificationsMap) UpdateAllNotifications(remoteConfigs []*Notification)
 	}
 }
 
+// UpdateNotify update namespace's notification ID
+func (n *notificationsMap) UpdateNotify(namespaceName string, notificationID int64) {
+	if namespaceName != "" {
+		n.setNotify(namespaceName, notificationID)
+	}
+}
+
 func (n *notificationsMap) setNotify(namespaceName string, notificationID int64) {
 	n.notifications.Store(namespaceName, notificationID)
 }

--- a/env/config/config_test.go
+++ b/env/config/config_test.go
@@ -99,3 +99,22 @@ func TestSplitNamespaces(t *testing.T) {
 	Assert(t, l, Equal(3))
 	w.Wait()
 }
+
+func TestNotificationsMap(t *testing.T) {
+	appConfig.Init()
+	ID := appConfig.GetNotificationsMap().GetNotify("application")
+	Assert(t, ID, Equal(int64(-1)))
+
+	appConfig.GetNotificationsMap().UpdateNotify("application", 3)
+	newID := appConfig.GetNotificationsMap().GetNotify("application")
+	Assert(t, newID, Equal(int64(3)))
+
+	appConfig.GetNotificationsMap().UpdateNotify("", 100)
+	noID := appConfig.GetNotificationsMap().GetNotify("")
+	Assert(t, noID, Equal(int64(0)))
+
+	appConfig.GetNotificationsMap().UpdateNotify("noExistNS", 3)
+	noExistID := appConfig.GetNotificationsMap().GetNotify("noExistNs")
+	Assert(t, noExistID, Equal(int64(0)))
+
+}


### PR DESCRIPTION
修复#164问题 
1.修改Sync方法，只拉取发生改变的namspace
2.只有拉取改变的namespace成功后，才更新notify id